### PR TITLE
Release 0.2.1

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17', '21' ]
+        java: [ '8', '11', '17', '21', '25' ]
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -681,6 +681,16 @@
         </profile>
 
         <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <puppycrawl-tools-checkstyle.version>8.18</puppycrawl-tools-checkstyle.version>
+            </properties>
+        </profile>
+
+        <profile>
             <id>java8+</id>
             <activation>
                 <jdk>[1.8,)</jdk>
@@ -716,9 +726,6 @@
             <activation>
                 <jdk>[11,)</jdk>
             </activation>
-            <properties>
-                <puppycrawl-tools-checkstyle.version>10.23.0</puppycrawl-tools-checkstyle.version>
-            </properties>
             <build>
                 <pluginManagement>
                     <plugins>


### PR DESCRIPTION
This pull request updates the build configuration to improve compatibility with multiple Java versions, specifically adding support for Java 25 and refining how dependencies are managed for different Java versions. The most significant changes are related to the Maven build matrix and the way the `puppycrawl-tools-checkstyle` dependency version is set for Java 8.

**Build and Dependency Management Improvements:**

* Added Java 25 to the build matrix in `.github/workflows/maven-build.yml`, ensuring CI tests run against the latest Java release.
* Introduced a new Maven profile `java8` in `pom.xml` that activates for JDK 1.8 and sets `puppycrawl-tools-checkstyle.version` to `8.18`, allowing for proper dependency management on Java 8.
* Removed the `puppycrawl-tools-checkstyle.version` property from the `java11+` profile, streamlining dependency configuration for newer Java versions.