### PR TITLE
Release 0.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -681,20 +681,13 @@
         </profile>
 
         <profile>
-            <id>puppycrawl-legacy</id>
-            <activation>
-                <jdk>[1.8,11)</jdk>
-            </activation>
-            <properties>
-                <puppycrawl-tools-checkstyle.version>8.18</puppycrawl-tools-checkstyle.version>
-            </properties>
-        </profile>
-
-        <profile>
             <id>java8+</id>
             <activation>
                 <jdk>[1.8,)</jdk>
             </activation>
+            <properties>
+                <puppycrawl-tools-checkstyle.version>9.3</puppycrawl-tools-checkstyle.version>
+            </properties>
             <build>
                 <pluginManagement>
                     <plugins>
@@ -722,10 +715,13 @@
         </profile>
 
         <profile>
-            <id>java11</id>
+            <id>java11+</id>
             <activation>
                 <jdk>[11,)</jdk>
             </activation>
+            <properties>
+                <puppycrawl-tools-checkstyle.version>10.26.1</puppycrawl-tools-checkstyle.version>
+            </properties>
             <build>
                 <pluginManagement>
                     <plugins>
@@ -764,6 +760,17 @@
                 </jvm.argLine>
             </properties>
         </profile>
+
+        <profile>
+            <id>java17+</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <properties>
+                <puppycrawl-tools-checkstyle.version>11.1.0</puppycrawl-tools-checkstyle.version>
+            </properties>
+        </profile>
+
     </profiles>
 
     <reporting>


### PR DESCRIPTION
This pull request updates the Maven build profiles in `pom.xml` to better support multiple Java versions and ensure the appropriate `puppycrawl-tools-checkstyle` version is used for each. The changes remove the old `java8` profile, update the `java11` profile, and add a new profile for Java 17 and above.

**Build profile updates:**

* Removed the `java8` profile and replaced it with a more general `java8+` profile, which now sets `puppycrawl-tools-checkstyle.version` to `9.3` for Java 8 and above.
* Renamed the `java11` profile to `java11+` and updated it to use `puppycrawl-tools-checkstyle.version` version `10.26.1` for Java 11 and above.
* Added a new `java17+` profile that activates for Java 17 and above, setting `puppycrawl-tools-checkstyle.version` to `11.1.0`.